### PR TITLE
Change request type from POST to GET for /list_branches and /products

### DIFF
--- a/margarita.py
+++ b/margarita.py
@@ -18,13 +18,13 @@ from reposadolib import reposadocommon
 def index():
     return render_template('margarita.html')
 
-@app.route('/list_branches', methods=['POST'])
+@app.route('/list_branches', methods=['GET'])
 def list_branches():
     '''Returns catalog branch names'''
     catalog_branches = reposadocommon.getCatalogBranches()
     return jsonify(result=catalog_branches)
 
-@app.route('/products', methods=['POST'])
+@app.route('/products', methods=['GET'])
 def products():
 	products = reposadocommon.getProductInfo()
 	prodlist = []

--- a/static/js/margarita.js
+++ b/static/js/margarita.js
@@ -75,7 +75,7 @@ function refresh_updates_table() {
     $("#swupdates").empty();
 
     // retrive list of branches
-    $.post("/list_branches", function(data) {
+    $.get("/list_branches", function(data) {
 	branches = data['result'];
 
 	// remove existing branch table columns
@@ -192,7 +192,7 @@ function toggle_queue_listing(e, prodid, branch) {
 function refresh_updates_rows() {
     // existing rows should not exist
 
-    $.post("/products", function(products) {
+    $.get("/products", function(products) {
 
 	var allrowtext = '';
 


### PR DESCRIPTION
When first testing out Margarita, I was watching the log (or actually the stdout output of `python margarita.py`) and was a bit concerned that my merely opening "http://localhost:8089" resulted in four POST requests.

Usually POST requests mean data is being modified on the server. After looking at the code, I noticed that you are using POST requests to get the list of branches and the list of products. Normally these would be GET operations, since data is being retrieved, and nothing is being changed.

This commit changes the request type of those two operations from POST to GET. Two very small changes to margarita.py and margarita.js.

Thanks for considering this change!

-Greg
