### PR TITLE
Hide deprecated and unlisted updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 preferences.plist
+reposadolib
+.DS_Store

--- a/static/js/margarita.js
+++ b/static/js/margarita.js
@@ -227,6 +227,7 @@ function refresh_updates_rows() {
 	    }
 
 	    // loop through branches
+	    unlistedCount = 0;
 	    $.each(branches, function(branch) {
 		text += '<td>' +
 		    '<button class="btn btn-mini ';
@@ -240,6 +241,7 @@ function refresh_updates_rows() {
 			'</td>';
 		} else {
 		    unlistedProducts = true;
+		    unlistedCount = unlistedCount + 1
 		    text += 'unlisted" onClick="toggle_queue_listing(this,' + "'" +
 			product['id'] + "','" + 
 			branch + "'" + ');"' +
@@ -253,7 +255,9 @@ function refresh_updates_rows() {
 	    
 	    // hide commonly listed items to save space
 	    if (unlistedProducts || (hideCommonlyListed == false) || (product['depr'] == true)) {
-		allrowtext += text;
+			if (!(hideCommonlyListed == true && product['depr'] == true && unlistedCount == branchct)) {
+				allrowtext += text;
+			}
 	    }
 	});
 	$("#swupdates").append(allrowtext);


### PR DESCRIPTION
When hiding commonly listed updates, also remove items that are listed as deprecated and don't appear in any of the user created branches.

Sample screen shots of the change:-
Hide commonly listed updates - off (current state)
![pre_hide_deprecated_and_unlisted](https://f.cloud.github.com/assets/2062699/240709/869e991a-8941-11e2-9f31-63f555ba36e3.png)

Hide commonly listed updates - on (hiding unlisted deprecated items)
![post_hide_deprecated_and_unlisted](https://f.cloud.github.com/assets/2062699/240711/c90d0bd8-8941-11e2-8273-1d8622746169.png)
