### PR TITLE
Hide deprecated updates unless in a branch

### DIFF
--- a/static/js/margarita.js
+++ b/static/js/margarita.js
@@ -138,11 +138,19 @@ var FilterCriteria = Backbone.Model.extend({
 	productFilter: function(product) {
 		var show = false;
 
-		if (this.get('hideCommon') == false || product.get('depr') == true) {
-			// always show the update if not hiding common updates OR if the update is deprecated
+		if (this.get('hideCommon') == false) {
+			// always show the update if not hiding common updates
 			show = true;
+		} else if (this.get('hideCommon') == true && product.get('depr') == true) {
+			// if the product is deprecated but still in a branch, show it when hiding common updates
+                        if (product.get('branches').length > 0){
+				show = true;
+			} else {
+				// don't show deprecated updates if hiding common updates and it's not in a branch
+				show = false;
+			}
 		} else {
-			var proddiff = _.difference(product.allBranches, product.get('branches'))
+			var proddiff = _.difference(product.allBranches, product.get('branches'));
 
 			// if we're not listed in all branches then show the update
 			if (proddiff.length != 0)  show = true;


### PR DESCRIPTION
This change has been proposed a couple times quite a few years ago in https://github.com/jessepeterson/margarita/pull/18 and a related PR at https://github.com/jessepeterson/margarita/pull/25. Those PRs are out dated with the current code now but I still think there there is value to this change.

This PR addresses the same change in the previous PRs where deprecated updates that are not in any custom branches are hidden when "Hide commonly listed updates" is checked.  

I understand wanting to see deprecated updates but aren't they only of visual value if they are still in a branch?  If an update is deprecated and not in any custom branches I don't know why that would need to be seen all the time.  I have lots of disk space so I rarely purge deprecated updates in case I need to reference them for historical reasons or for reference when assisting another admin. The unused, deprecated updates don't need to be seen they just need to be accessible which they are in the view when not hiding common updates.

-Eric